### PR TITLE
Allow multi outputs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,9 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.6
+      language_version: python3.7
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: ''  # Use the sha / tag you want to point at
+    hooks:
+    - id: mypy
+      args: [--no-strict-optional, --ignore-missing-imports]

--- a/README.md
+++ b/README.md
@@ -93,7 +93,15 @@ If the field is left blank, it will be simply ignored.
 Example file:
 
 ```yaml
-- python: 3.6
+python:
+  - 3.7
+# in case of matrix build, multiple versions can be added
+  - 3.8
+  - 3.9
+
+qt:
+  - 5.12
+
 
 pin_run_as_build:
   python: x.x

--- a/dev/environment-dev.yaml
+++ b/dev/environment-dev.yaml
@@ -7,7 +7,8 @@ dependencies:
   - bumpversion
   - conda-build
   - conda-verify
+  - mypy
   - pre_commit
   - pytest
   - pytest-mock
-  - yaml
+  - ruamel.yaml

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "anaconda-client",
         "conda-build>=3.18.10",
         "conda-verify",
-        "pyyaml",
+        "ruamel.yaml",
     ],
     entry_points={
         "console_scripts": ["publish-conda-stack = publish_conda_stack.__main__:main"]

--- a/src/publish_conda_stack/core.py
+++ b/src/publish_conda_stack/core.py
@@ -16,7 +16,7 @@ import sys
 import tempfile
 import time
 import typing
-import yaml
+import ruamel.yaml as yaml
 
 
 logger = logging.getLogger()

--- a/src/publish_conda_stack/core.py
+++ b/src/publish_conda_stack/core.py
@@ -484,7 +484,8 @@ def get_rendered_version(
     ).decode()
 
     name_version_builds = [
-        CCPkgName(*Path(x).name.split("-")) for x in rendered_filenames.split()
+        CCPkgName(*Path(x).name.replace(".tar.bz2", "").split("-"))
+        for x in rendered_filenames.split()
     ]
 
     if not all(x.package_name == package_name for x in name_version_builds):

--- a/src/publish_conda_stack/util.py
+++ b/src/publish_conda_stack/util.py
@@ -1,8 +1,8 @@
 import re
-import typing
+from typing import List, Tuple, Union
 
 
-def labels_to_upload_string(label_list: typing.List[str]) -> str:
+def labels_to_upload_string(label_list: List[str]) -> str:
     """generates a string suitable for anaconda upload
 
     Examples:
@@ -15,9 +15,7 @@ def labels_to_upload_string(label_list: typing.List[str]) -> str:
     return " ".join(f"--label {label}" for label in label_list)
 
 
-def labels_to_search_string(
-    destination_channel: str, label_list: typing.List[str]
-) -> str:
+def labels_to_search_string(destination_channel: str, label_list: List[str]) -> str:
     """generates a string suitable for conda search
 
     Examples:
@@ -33,7 +31,7 @@ def labels_to_search_string(
     )
 
 
-def strip_label(channel_string: str) -> str:
+def strip_label(channel_string: str) -> Tuple[str, Union[str, None]]:
     """Remove label from channel string
 
     Args:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,3 @@
-from unittest.mock import Mock, patch
 from publish_conda_stack.core import get_rendered_version
 
 import pytest
@@ -34,24 +33,24 @@ import pytest
         ),
     ],
 )
-def test_get_rendered_version(c_package_names, expected):
-    subprocess_mock = Mock()
+def test_get_rendered_version(mocker, c_package_names, expected):
+    subprocess_mock = mocker.Mock()
     subprocess_mock.return_value = c_package_names.encode()
-    with patch("subprocess.check_output", new=subprocess_mock):
-        res = get_rendered_version(
-            "abc", "mock_path", "bld_env", {"source-channel-string": "ignore"}, None
-        )
+    mocker.patch("subprocess.check_output", new=subprocess_mock)
+    res = get_rendered_version(
+        "abc", "mock_path", "bld_env", {"source-channel-string": "ignore"}, None
+    )
 
     assert len(res) == len(expected)
 
 
-def test_get_rendered_version_raises():
-    subprocess_mock = Mock()
+def test_get_rendered_version_raises(mocker):
+    subprocess_mock = mocker.Mock()
     subprocess_mock.return_value = (
         "/some/path/abc-1.0.0-0py0\n/some/path/notabc-1.0.0-1py2,".encode()
     )
-    with patch("subprocess.check_output", new=subprocess_mock):
-        with pytest.raises(RuntimeError):
-            _ = get_rendered_version(
-                "abc", "mock_path", "bld_env", {"source-channel-string": "ignore"}, None
-            )
+    mocker.patch("subprocess.check_output", new=subprocess_mock)
+    with pytest.raises(RuntimeError):
+        _ = get_rendered_version(
+            "abc", "mock_path", "bld_env", {"source-channel-string": "ignore"}, None
+        )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,57 @@
+from unittest.mock import Mock, patch
+from publish_conda_stack.core import get_rendered_version
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "c_package_names,expected",
+    [
+        (
+            "/some/path/abc-1.0.0-0py0,",
+            (
+                (
+                    "abc",
+                    "1.0.0",
+                    "0py0",
+                ),
+            ),
+        ),
+        (
+            "/some/path/abc-1.0.0-0py0\n/some/path/abc-1.0.0-1py2,",
+            (
+                (
+                    "abc",
+                    "1.0.0",
+                    "0py0",
+                ),
+                (
+                    "abc",
+                    "1.0.0",
+                    "1py2",
+                ),
+            ),
+        ),
+    ],
+)
+def test_get_rendered_version(c_package_names, expected):
+    subprocess_mock = Mock()
+    subprocess_mock.return_value = c_package_names.encode()
+    with patch("subprocess.check_output", new=subprocess_mock):
+        res = get_rendered_version(
+            "abc", "mock_path", "bld_env", {"source-channel-string": "ignore"}, None
+        )
+
+    assert len(res) == len(expected)
+
+
+def test_get_rendered_version_raises():
+    subprocess_mock = Mock()
+    subprocess_mock.return_value = (
+        "/some/path/abc-1.0.0-0py0\n/some/path/notabc-1.0.0-1py2,".encode()
+    )
+    with patch("subprocess.check_output", new=subprocess_mock):
+        with pytest.raises(RuntimeError):
+            _ = get_rendered_version(
+                "abc", "mock_path", "bld_env", {"source-channel-string": "ignore"}, None
+            )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,4 @@
-from publish_conda_stack.core import get_rendered_version
+from publish_conda_stack.core import get_rendered_version, CCPkgName
 
 import pytest
 
@@ -7,9 +7,9 @@ import pytest
     "c_package_names,expected",
     [
         (
-            "/some/path/abc-1.0.0-0py0,",
+            "/some/path/abc-1.0.0-0py0.tar.bz2",
             (
-                (
+                CCPkgName(
                     "abc",
                     "1.0.0",
                     "0py0",
@@ -17,14 +17,14 @@ import pytest
             ),
         ),
         (
-            "/some/path/abc-1.0.0-0py0\n/some/path/abc-1.0.0-1py2,",
+            "/some/path/abc-1.0.0-0py0.tar.bz2\n/some/path/abc-1.0.0-1py2.tar.bz2",
             (
-                (
+                CCPkgName(
                     "abc",
                     "1.0.0",
                     "0py0",
                 ),
-                (
+                CCPkgName(
                     "abc",
                     "1.0.0",
                     "1py2",
@@ -42,13 +42,12 @@ def test_get_rendered_version(mocker, c_package_names, expected):
     )
 
     assert len(res) == len(expected)
+    assert res == expected
 
 
 def test_get_rendered_version_raises(mocker):
     subprocess_mock = mocker.Mock()
-    subprocess_mock.return_value = (
-        "/some/path/abc-1.0.0-0py0\n/some/path/notabc-1.0.0-1py2,".encode()
-    )
+    subprocess_mock.return_value = "/some/path/abc-1.0.0-0py0.tar.bz2\n/some/path/notabc-1.0.0-1py2.tar.bz2,".encode()
     mocker.patch("subprocess.check_output", new=subprocess_mock)
     with pytest.raises(RuntimeError):
         _ = get_rendered_version(


### PR DESCRIPTION
fixes #23, somewhat.

At least allows matrix like builds. For now I didn't venture into the multi-output packages, that would produce packages with different package names - for now. Might not be an issue at all, but just to keep it simple for now.

so this would allow pins like (so I think the whole magic of the cbc):

```yaml
python:
  - 3.7
  - 3.8
  - 3.9
qt:
  - 5.12
```

What I have not looked into yet:

* what happens if one of the package from a matrix build is there. Right now it will build/upload all, except for when _all_ packages are found.
