### PR TITLE
Fix package finding

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0dev1
+current_version = 0.3.0dev2
 commit = False
 tag = False
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="publish-conda-stack",
-    version="0.3.0dev1",
+    version="0.3.0dev2",
     author="Stuart Berg, Carsten Haubold",
     author_email="team@ilastik.org",
     license="MIT",

--- a/src/publish_conda_stack/__init__.py
+++ b/src/publish_conda_stack/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.0dev1"
+__version__ = "0.3.0dev2"

--- a/src/publish_conda_stack/core.py
+++ b/src/publish_conda_stack/core.py
@@ -594,7 +594,7 @@ def upload_package(
         package_paths.append(pkg_file_path)
 
     upload_cmd = (
-        f"anaconda {shared_config['token-string']} upload -u {shared_config['upload-channel']}"
+        f"anaconda {shared_config['token-string']} upload --skip-existing -u {shared_config['upload-channel']}"
         f" {labels_to_upload_string(shared_config['labels'])} "
         f"{' '.join(package_paths)}"
     )

--- a/src/publish_conda_stack/core.py
+++ b/src/publish_conda_stack/core.py
@@ -513,18 +513,14 @@ def check_already_exists(
     package_name = c_pkg_names[0].package_name
     logger.info(f"Searching channel: {shared_config['destination-channel']}")
     search_cmd = (
-        f"conda search --json  --full-name --override-channels"
-        f" --channel={shared_config['upload-channel']}"
+        f"conda search --json --full-name --override-channels"
+        f" --channel {shared_config['upload-channel']}"
         f" {labels_to_search_string(shared_config['upload-channel'], shared_config['labels'])}"
         f" {package_name}"
     )
     logger.info(search_cmd)
-    try:
-        search_results_text = subprocess.check_output(search_cmd, shell=True).decode()
-    except Exception:
-        # In certain scenarios, the search can crash.
-        # In such cases, the package wasn't there anyway, so return False
-        return tuple((c_pkg, False) for c_pkg in c_pkg_names)
+
+    search_results_text = subprocess.check_output(search_cmd, shell=True).decode()
 
     search_results = json.loads(search_results_text)
 
@@ -533,15 +529,17 @@ def check_already_exists(
 
     c_pkgs_found: List[Tuple[CCPkgName, bool]] = []
     for c_pkg_name in c_pkg_names:
+        found = False
         for result in search_results[package_name]:
             if (
                 result["build"] == c_pkg_name.build_string
                 and result["version"] == c_pkg_name.version
             ):
+                found = True
                 logger.info(f"Found package {c_pkg_name}")
-                c_pkgs_found.append((c_pkg_name, True))
-            else:
-                c_pkgs_found.append((c_pkg_name, False))
+                break
+
+        c_pkgs_found.append((c_pkg_name, found))
 
     return tuple(c_pkgs_found)
 

--- a/tests/test_conda_interface.py
+++ b/tests/test_conda_interface.py
@@ -1,4 +1,4 @@
-from publish_conda_stack.core import upload_package, CCPkgName
+from publish_conda_stack.core import get_rendered_version, upload_package, CCPkgName
 from publish_conda_stack.util import labels_to_upload_string
 import os
 import pytest
@@ -207,3 +207,69 @@ def test_upload_multiple(mocker):
         f"anaconda {token_string} upload -u {test_channel} {label_string} {' '.join(test_paths)}",
         shell=True,
     )
+
+
+@pytest.mark.parametrize(
+    "c_package_names,expected",
+    [
+        (
+            "/some/path/abc-1.0.0-0py0.tar.bz2",
+            (
+                CCPkgName(
+                    "abc",
+                    "1.0.0",
+                    "0py0",
+                ),
+            ),
+        ),
+        (
+            "/some/path/abc-1.0.0-0py0.tar.bz2\n/some/path/abc-1.0.0-1py2.tar.bz2",
+            (
+                CCPkgName(
+                    "abc",
+                    "1.0.0",
+                    "0py0",
+                ),
+                CCPkgName(
+                    "abc",
+                    "1.0.0",
+                    "1py2",
+                ),
+            ),
+        ),
+    ],
+)
+def test_get_rendered_version(mocker, c_package_names, expected):
+    subprocess_mock = mocker.Mock()
+    subprocess_mock.return_value = c_package_names.encode()
+    mocker.patch("subprocess.check_output", new=subprocess_mock)
+    res = get_rendered_version(
+        "abc", "mock_path", "bld_env", {"source-channel-string": "ignore"}, None
+    )
+
+    assert len(res) == len(expected)
+    assert res == expected
+
+
+def test_get_rendered_version_raises(mocker):
+    subprocess_mock = mocker.Mock()
+    subprocess_mock.return_value = "/some/path/abc-1.0.0-0py0.tar.bz2\n/some/path/notabc-1.0.0-1py2.tar.bz2".encode()
+    mocker.patch("subprocess.check_output", new=subprocess_mock)
+    with pytest.raises(RuntimeError):
+        _ = get_rendered_version(
+            "abc", "mock_path", "bld_env", {"source-channel-string": "ignore"}, None
+        )
+
+
+def test_get_rendered_version_ignores_patch_outputs(mocker):
+    subprocess_mock = mocker.Mock()
+    subprocess_mock.return_value = "Patch level ambiguous, selecting least deep\nPatch analysis gives:\n[[ RA-MD1--VE ]] - [[                                       0001-fix-whatever.patch ]]\n\nKey:\n\nR :: Reversible                       A :: Applicable\nY :: Build-prefix patch in use        M :: Minimal, non-amalgamated\nD :: Dry-runnable                     N :: Patch level (1 is preferred)\nL :: Patch level not-ambiguous        O :: Patch applies without offsets\nV :: Patch applies without fuzz       E :: Patch applies without emitting to stderr\n\n/some/path/abc-1.0.0-0py0whatever.tar.bz2\n".encode()
+    mocker.patch("subprocess.check_output", new=subprocess_mock)
+    expected = CCPkgName("abc", "1.0.0", "0py0whatever")
+
+    res = get_rendered_version(
+        "abc", "mock_path", "bld_env", {"source-channel-string": "ignore"}, None
+    )
+
+    assert len(res) == 1
+    assert res[0] == expected

--- a/tests/test_conda_interface.py
+++ b/tests/test_conda_interface.py
@@ -48,7 +48,7 @@ def test_upload(mocker, labels, token_string):
     )
     assert os.path.exists.call_count == 2
     subprocess.check_call.assert_called_once_with(
-        f"anaconda {token_string} upload -u {test_channel} {label_string} {test_path}",
+        f"anaconda {token_string} upload --skip-existing -u {test_channel} {label_string} {test_path}",
         shell=True,
     )
 
@@ -83,7 +83,7 @@ def test_hide_token(mocker):
         f"{platform}-{arch}",
         f"{package_name}-{recipe_version}-{recipe_build_string}.tar.bz2",
     )
-    cmd = f"anaconda {token_string} upload -u {test_channel} {label_string} {test_path}"
+    cmd = f"anaconda {token_string} upload --skip-existing -u {test_channel} {label_string} {test_path}"
 
     def side_effect(callable_str, *args, **kwargs):
         raise subprocess.CalledProcessError(cmd=callable_str, returncode=1)
@@ -148,7 +148,7 @@ def test_upload_channel(mocker):
     )
     assert os.path.exists.call_count == 2
     subprocess.check_call.assert_called_once_with(
-        f"anaconda {token_string} upload -u {test_channel} {label_string} {test_path}",
+        f"anaconda {token_string} upload --skip-existing -u {test_channel} {label_string} {test_path}",
         shell=True,
     )
 
@@ -204,7 +204,7 @@ def test_upload_multiple(mocker):
     assert os.path.exists.call_count == 2 * len(test_paths)
 
     subprocess.check_call.assert_called_once_with(
-        f"anaconda {token_string} upload -u {test_channel} {label_string} {' '.join(test_paths)}",
+        f"anaconda {token_string} upload --skip-existing -u {test_channel} {label_string} {' '.join(test_paths)}",
         shell=True,
     )
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,10 @@
-from publish_conda_stack.core import get_rendered_version, CCPkgName
+from textwrap import dedent
+
+from publish_conda_stack.core import (
+    check_already_exists,
+    get_rendered_version,
+    CCPkgName,
+)
 
 import pytest
 
@@ -67,3 +73,85 @@ def test_get_rendered_version_ignores_patch_outputs(mocker):
 
     assert len(res) == 1
     assert res[0] == expected
+
+
+def test_check_already_exists(mocker):
+    c_pkg_names = (CCPkgName("mypack", "1.0", "py38_0_hblah"),)
+    shared_config = {
+        "destination-channel": "mock-channel",
+        "labels": ["test"],
+        "upload-channel": "blah-forge",
+    }
+
+    subprocess_mock = mocker.Mock()
+    subprocess_mock.return_value = dedent(
+        """
+    {
+      "mypack": [
+        {
+          "build": "py38_0_hblah",
+          "build_number": 0,
+          "name": "mypack",
+          "version": "1.0"
+        }
+      ]
+    }
+    """
+    ).encode()
+    mocker.patch("subprocess.check_output", new=subprocess_mock)
+
+    pkgs_found = check_already_exists(c_pkg_names, shared_config)
+
+    subprocess_mock.assert_called_once_with(
+        "conda search --json --full-name --override-channels "
+        "--channel blah-forge --channel blah-forge/label/test mypack",
+        shell=True,
+    )
+
+    assert len(pkgs_found) == 1
+    assert pkgs_found[0][0] == c_pkg_names[0]
+    assert pkgs_found[0][1]
+
+
+def test_check_already_exists_doesnt_add(mocker):
+    c_pkg_names = (CCPkgName("mypack", "1.0", "py38_0_hblah"),)
+    shared_config = {
+        "destination-channel": "mock-channel",
+        "labels": ["test"],
+        "upload-channel": "blah-forge",
+    }
+
+    subprocess_mock = mocker.Mock()
+    subprocess_mock.return_value = dedent(
+        """
+    {
+      "mypack": [
+        {
+          "build": "py38_0_hblah",
+          "build_number": 0,
+          "name": "mypack",
+          "version": "1.0"
+        },
+        {
+          "build": "py38_0_hblah",
+          "build_number": 0,
+          "name": "mypack",
+          "version": "0.9"
+        }
+      ]
+    }
+    """
+    ).encode()
+    mocker.patch("subprocess.check_output", new=subprocess_mock)
+
+    pkgs_found = check_already_exists(c_pkg_names, shared_config)
+
+    subprocess_mock.assert_called_once_with(
+        "conda search --json --full-name --override-channels "
+        "--channel blah-forge --channel blah-forge/label/test mypack",
+        shell=True,
+    )
+
+    assert len(pkgs_found) == 1
+    assert pkgs_found[0][0] == c_pkg_names[0]
+    assert pkgs_found[0][1]


### PR DESCRIPTION
Again, making you @stuarteberg aware some fix ;) and some not so elegant behavior:

if you have a matrix build, let's say for multiple python versions, then it will currently only skip building if _all_ are found. If one is missing, it will rebuild all (but not fail on upload).
