### PR TITLE
fix for win-style line-endings

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0dev2
+current_version = 0.3.0dev3
 commit = False
 tag = False
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="publish-conda-stack",
-    version="0.3.0dev2",
+    version="0.3.0dev3",
     author="Stuart Berg, Carsten Haubold",
     author_email="team@ilastik.org",
     license="MIT",

--- a/src/publish_conda_stack/__init__.py
+++ b/src/publish_conda_stack/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.0dev2"
+__version__ = "0.3.0dev3"

--- a/src/publish_conda_stack/core.py
+++ b/src/publish_conda_stack/core.py
@@ -484,7 +484,7 @@ def get_rendered_version(
     ).decode()
 
     rendered_filenames = [
-        x for x in subprocess_output.split("\n") if x.endswith(".tar.bz2")
+        x for x in subprocess_output.split() if x.endswith(".tar.bz2")
     ]
 
     name_version_builds = [

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -37,6 +37,22 @@ import pytest
                 ),
             ),
         ),
+        # windows style line endings
+        (
+            "/some/path/abc-1.0.0-0py0.tar.bz2\r\n/some/path/abc-1.0.0-1py2.tar.bz2",
+            (
+                CCPkgName(
+                    "abc",
+                    "1.0.0",
+                    "0py0",
+                ),
+                CCPkgName(
+                    "abc",
+                    "1.0.0",
+                    "1py2",
+                ),
+            ),
+        ),
     ],
 )
 def test_get_rendered_version(mocker, c_package_names, expected):


### PR DESCRIPTION
:disappointed: script would only get the last rendered package name due to `\r\n`...

cc @stuarteberg 