### PR TITLE
Fix pkg not exists

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -3,10 +3,10 @@
 ## Create a development environment
 
 ```bash
-conda env create --file dev/environment-dev.py
+mamba env create --name pcs-dev --file dev/environment-dev.yml
 ```
 
-This will create an environment with the name `pcs-dev`, that can be activated with `conda activate pcs-dev`.
+This will create an environment with the name `pcs-dev`, that can be activated with `mamba activate pcs-dev`.
 
 ## Automatic versioning with bumpversion
 

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -1,4 +1,3 @@
-name: pcs-dev
 channels:
   - conda-forge
 dependencies:

--- a/src/publish_conda_stack/core.py
+++ b/src/publish_conda_stack/core.py
@@ -524,7 +524,14 @@ def check_already_exists(
     search_cmd = conda_cmd_base(CondaCommand.SEARCH, shared_config) + [package_name]
     logger.info(" ".join(search_cmd))
 
-    search_results_text = subprocess.check_output(search_cmd).decode()
+    try:
+        search_results_text = subprocess.check_output(search_cmd).decode()
+    except subprocess.CalledProcessError as e:
+        output = e.output.decode()
+        if "following packages are not available from current channels" in output:
+            search_results_text = r"{}"
+        else:
+            raise e
 
     search_results = json.loads(search_results_text)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,12 +1,13 @@
+import subprocess
 from textwrap import dedent
 
+import pytest
+
 from publish_conda_stack.core import (
+    CCPkgName,
     check_already_exists,
     get_rendered_version,
-    CCPkgName,
 )
-
-import pytest
 
 
 @pytest.mark.parametrize(
@@ -204,3 +205,79 @@ def test_check_already_exists_doesnt_add(mocker):
     assert len(pkgs_found) == 1
     assert pkgs_found[0][0] == c_pkg_names[0]
     assert pkgs_found[0][1]
+
+
+def test_check_already_exists_not_found(mocker):
+    c_pkg_names = (CCPkgName("mypack", "1.0", "py38_0_hblah"),)
+    shared_config = {
+        "destination-channel": "mock-channel",
+        "labels": ["test"],
+        "upload-channel": "blah-forge",
+    }
+
+    output = dedent(
+        """
+        The following packages are not available from current channels:
+
+          - ilastik-launch
+
+        Current channels:
+
+          - https://conda.anaconda.org/mock_channel/osx-64
+          - https://conda.anaconda.org/mock_channel/noarch
+
+        To search for alternate channels that may provide the conda package you're
+        looking for, navigate to
+
+            https://anaconda.org
+
+        and use the search bar at the top of the page.
+
+        Traceback (most recent call last):
+          File "/Users/user/mambaforge/bin/publish-conda-stack", line 10, in <module>
+            sys.exit(main())
+          File "/Users/user/mambaforge/lib/python3.9/site-packages/publish_conda_stack/core.py", line 227, in main
+            raise e
+          File "/Users/user/mambaforge/lib/python3.9/site-packages/publish_conda_stack/core.py", line 223, in main
+            status = build_and_upload_recipe(spec, shared_config, conda_bld_config)
+          File "/Users/user/mambaforge/lib/python3.9/site-packages/publish_conda_stack/core.py", line 390, in build_and_upload_recipe
+            packages_found = check_already_exists(c_pkg_names, shared_config)
+          File "/Users/user/mambaforge/lib/python3.9/site-packages/publish_conda_stack/core.py", line 527, in check_already_exists
+            search_results_text = subprocess.check_output(search_cmd).decode()
+          File "/Users/user/mambaforge/lib/python3.9/subprocess.py", line 424, in check_output
+            return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
+          File "/Users/user/mambaforge/lib/python3.9/subprocess.py", line 528, in run
+            raise CalledProcessError(retcode, process.args,
+        subprocess.CalledProcessError: Command '['mamba', 'search', '--json', '--full-name', '--override-channels', '--channel', 'mock_channel', 'mypack']' returned non-zero exit status 1.
+    """
+    ).encode()
+
+    mock_error = subprocess.CalledProcessError(
+        returncode=1,
+        cmd="['mamba', 'search', '--json', '--full-name', '--override-channels', '--channel', 'ilastik-forge', 'ilastik-launch']",
+        output=output,
+    )
+
+    subprocess_mock = mocker.Mock(side_effect=mock_error)
+    mocker.patch("subprocess.check_output", new=subprocess_mock)
+
+    pkgs_found = check_already_exists(c_pkg_names, shared_config)
+
+    subprocess_mock.assert_called_once_with(
+        [
+            "conda",
+            "search",
+            "--json",
+            "--full-name",
+            "--override-channels",
+            "--channel",
+            "blah-forge",
+            "--channel",
+            "blah-forge/label/test",
+            "mypack",
+        ]
+    )
+
+    assert len(pkgs_found) == 1
+    assert pkgs_found[0][0] == c_pkg_names[0]
+    assert not pkgs_found[0][1]


### PR DESCRIPTION
previously `publish-conda-stack` would fail if package did not already exist in destination channel.

fixes #35 