### PR TITLE
Fix ruamel deprecation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           auto-activate-base: true
           activate-environment: ""
       - name: install common dependencies
-        run: conda install -n base -c conda-forge conda-build mamba boa -y
+        run: conda install -n base -c conda-forge -c nodefaults conda-build mamba boa -y
       - name: linux conda build test
         if: matrix.os == 'ubuntu-latest'
         shell: bash -l {0}
@@ -33,3 +33,8 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: cmd /C CALL {0}
         run: conda mambabuild -c conda-forge conda-recipe
+        # HACK: due to a bug in conda-build need to point to
+        # libarchive explicitly.
+        # https://github.com/conda/conda/issues/12563#issuecomment-1494264704
+        env:
+          LIBARCHIVE: C:\Miniconda\Library\bin\archive.dll

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 24.1.1
     hooks:
     - id: black
       language_version: python3.9
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: ''  # Use the sha / tag you want to point at
+    rev: 'v1.8.0'  # Use the sha / tag you want to point at
     hooks:
     - id: mypy
       args: [--no-strict-optional, --ignore-missing-imports]
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.13.2
   hooks:
     - id: isort
       name: isort (python)

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,13 @@ setup(
     packages=find_packages("./src"),
     include_package_data=True,
     install_requires=[
-        "argcomplete",
         "anaconda-client",
+        "argcomplete",
+        "boa",
         "conda-build>=3.18.10",
         "conda-verify",
-        "ruamel.yaml>=0.15.2",
         "mamba",
-        "boa",
+        "ruamel.yaml>=0.15.2",
     ],
     entry_points={
         "console_scripts": ["publish-conda-stack = publish_conda_stack.__main__:main"]

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "anaconda-client",
         "conda-build>=3.18.10",
         "conda-verify",
-        "ruamel.yaml",
+        "ruamel.yaml>=0.15.2",
         "mamba",
         "boa",
     ],

--- a/src/publish_conda_stack/core.py
+++ b/src/publish_conda_stack/core.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 import conda_build.api
-import ruamel.yaml as yaml
+from ruamel.yaml import YAML
 
 from . import __version__
 from .cmdutil import CondaCommand, conda_cmd_base
@@ -92,9 +92,8 @@ def parse_cmdline_args():
     if ENABLE_TAB_COMPLETION:
 
         def complete_recipe_selection(prefix, action, parser, parsed_args):
-            specs_file_contents = yaml.safe_load(
-                open(parsed_args.recipe_specs_path, "r")
-            )
+            yaml = YAML(typ="safe")
+            specs_file_contents = yaml.load(open(parsed_args.recipe_specs_path, "r"))
             recipe_specs = specs_file_contents["recipe-specs"]
             names = (spec["name"] for spec in recipe_specs)
             return filter(lambda name: name.startswith(prefix), names)
@@ -110,7 +109,8 @@ def parse_cmdline_args():
 def parse_specs(args):
 
     specs_dir = Path(dirname(abspath(args.recipe_specs_path)))
-    specs_file_contents = yaml.safe_load(open(args.recipe_specs_path, "r"))
+    yaml = YAML(typ="safe")
+    specs_file_contents = yaml.load(open(args.recipe_specs_path, "r"))
 
     # Read the 'shared-config' section
     shared_config = specs_file_contents["shared-config"]
@@ -235,17 +235,21 @@ def main():
     result["duration"] = str(end_time - start_time)
     write_result(result_file, result)
 
+    yaml = YAML(typ="safe")
+    yaml.default_flow_style = False
     print("--------")
     print(f"DONE, Result written to {result_file}")
     print("--------")
     print("Summary:")
-    print(yaml.dump(result, default_flow_style=False))
+    print(yaml.dump(result))
 
 
 def write_result(result_file_name, result):
     result["last_updated"] = datetime.datetime.now().isoformat(timespec="seconds")
+    yaml = YAML(typ="safe")
+    yaml.default_flow_style = False
     with open(result_file_name, "w") as f:
-        yaml.dump(result, f, default_flow_style=False)
+        yaml.dump(result, f)
 
 
 def print_recipe_list(recipe_specs):


### PR DESCRIPTION
`publish-conda-stack` has stopped working with current versions of `ruamel.yaml`.

@stuarteberg: I don't know if you're still using this package, but it now it should also work with newer versions of `ruamel.yaml`....